### PR TITLE
[Fix] Codeowners team name fixed

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, they will
 # be requested for review when someone opens a PR.
-* @FlorenceHC/@development-team
+* @FlorenceHC/development-team
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches ruby files, only these owners


### PR DESCRIPTION
### Implementation Details :construction:

- Updated codeowners team name (e.g. fixed team reference).